### PR TITLE
Include magic.h in dist/

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,4 +17,5 @@ make clean
 make -j4
 cp src/.libs/libmagic-1.dll ../dist/
 cp src/.libs/file.exe ../dist/
+cp src/magic.h ../dist/
 cp COPYING ../dist/COPYING.file


### PR DESCRIPTION
magic-haskell needs `magic.h` in order to build.